### PR TITLE
Change Admin's menubar tab to selectbox

### DIFF
--- a/padrino-admin/lib/padrino-admin/generators/templates/assets/javascripts/model-selector.js
+++ b/padrino-admin/lib/padrino-admin/generators/templates/assets/javascripts/model-selector.js
@@ -1,0 +1,13 @@
+!function($) {
+  'use strict';
+
+  $(function() {
+    var selector = $("#model-selector");
+    selector.change(function(){
+      var path = $(this).children(':selected').val();
+      if(path !== ""){
+        location.href = path;
+      }
+    });
+  });
+}(window.jQuery);

--- a/padrino-admin/lib/padrino-admin/generators/templates/erb/app/layouts/application.erb.tt
+++ b/padrino-admin/lib/padrino-admin/generators/templates/erb/app/layouts/application.erb.tt
@@ -29,7 +29,7 @@
             <select name="model" class="navbar-module" id="model-selector"> 
             <option />
             <%% project_modules.sort_by{|m| m.human_name}.each do |project_module| %>
-            <option value="<%= url(project_module.path) %>" 
+            <option value="<%%= url(project_module.path) %>" 
               <%% if request.path_info =~ /^#{project_module.path}/ %>
                 selected
               <%% else %>

--- a/padrino-admin/lib/padrino-admin/generators/templates/erb/app/layouts/application.erb.tt
+++ b/padrino-admin/lib/padrino-admin/generators/templates/erb/app/layouts/application.erb.tt
@@ -25,15 +25,21 @@
           </ul>
 
           <ul class="nav navbar-nav pull-left">
-            <%% project_modules.each do |project_module| %>
+            <form action"/" method="get">
+            <select name="model" class="navbar-module" id="model-selector"> 
+            <option />
+            <%% project_modules.sort_by{|m| m.human_name}.each do |project_module| %>
+            <option value="<%= url(project_module.path) %>" 
               <%% if request.path_info =~ /^#{project_module.path}/ %>
-                <li class="navbar-module active">
+                selected
               <%% else %>
-                <li class=navbar-module>
               <%% end %>
-                <%%= link_to project_module.human_name, url(project_module.path) %>
-                </li>
+               class="model">
+                <%%= project_module.human_name %>
+            </option>
             <%% end %>
+            </select>
+            </form>
           </ul>
         </div>
       </div>
@@ -59,6 +65,6 @@
       </div>
     </footer>
 
-    <%%= javascript_include_tag 'jquery-1.11.0.min', (Padrino.env == :production ? 'bootstrap/bootstrap.min' : %w[bootstrap/affix bootstrap/alert bootstrap/button bootstrap/carousel bootstrap/collapse bootstrap/dropdown  bootstrap/tooltip bootstrap/transition  bootstrap/modal bootstrap/popover bootstrap/scrollspy bootstrap/tab]), :application %>
+    <%%= javascript_include_tag 'jquery-1.11.0.min', (Padrino.env == :production ? 'bootstrap/bootstrap.min' : %w[bootstrap/affix bootstrap/alert bootstrap/button bootstrap/carousel bootstrap/collapse bootstrap/dropdown  bootstrap/tooltip bootstrap/transition  bootstrap/modal bootstrap/popover bootstrap/scrollspy bootstrap/tab]), :application, 'model-selector'%>
   </body>
 </html>

--- a/padrino-admin/lib/padrino-admin/generators/templates/erb/app/layouts/application.erb.tt
+++ b/padrino-admin/lib/padrino-admin/generators/templates/erb/app/layouts/application.erb.tt
@@ -24,7 +24,7 @@
             </li>
           </ul>
 
-          <ul class="nav navbar-nav pull-left">
+          <ul class="nav navbar-nav pull-left" style="margin-top:20px">
             <form action"/" method="get">
             <select name="model" class="navbar-module" id="model-selector"> 
             <option />


### PR DESCRIPTION
Padrino admin page's menu is uncomfortable when too many models exist.
So I fixed to use selectbox.
When item is selected in this box, you jump to target page.
