### PR TITLE
Fix nested require dependencies

### DIFF
--- a/padrino-core/lib/padrino-core/reloader.rb
+++ b/padrino-core/lib/padrino-core/reloader.rb
@@ -138,6 +138,13 @@ module Padrino
       @special_files = Set.new(files)
     end
 
+    ###
+    # Macro for mtime remove.
+    #
+    def remove_modification_time(file)
+      MTIMES.delete(file)
+    end
+
     private
 
     ##

--- a/padrino-core/lib/padrino-core/reloader/storage.rb
+++ b/padrino-core/lib/padrino-core/reloader/storage.rb
@@ -41,7 +41,14 @@ module Padrino
 
       def rollback(name)
         new_constants = ObjectSpace.new_classes(@old_entries[name][:constants])
-        new_constants.each{ |klass| Reloader.remove_constant(klass) }
+        new_constants.each do |klass|
+          files.each do |file|
+            if file[1][:constants].include?(klass)
+              Reloader.clear_modification_time(file[0])
+            end
+          end
+          Reloader.remove_constant(klass)
+        end
         @old_entries.delete(name)
       end
 

--- a/padrino-core/lib/padrino-core/reloader/storage.rb
+++ b/padrino-core/lib/padrino-core/reloader/storage.rb
@@ -44,7 +44,7 @@ module Padrino
         new_constants.each do |klass|
           files.each do |file|
             if file[1][:constants].include?(klass)
-              Reloader.clear_modification_time(file[0])
+              Reloader.remove_modification_time(file[0])
             end
           end
           Reloader.remove_constant(klass)

--- a/padrino-core/test/fixtures/dependencies/nested/j.rb
+++ b/padrino-core/test/fixtures/dependencies/nested/j.rb
@@ -1,0 +1,2 @@
+class J < K
+end

--- a/padrino-core/test/fixtures/dependencies/nested/k.rb
+++ b/padrino-core/test/fixtures/dependencies/nested/k.rb
@@ -1,0 +1,2 @@
+class K
+end

--- a/padrino-core/test/fixtures/dependencies/nested/l.rb
+++ b/padrino-core/test/fixtures/dependencies/nested/l.rb
@@ -1,0 +1,4 @@
+Padrino.require_dependencies(
+  Padrino.root("fixtures/dependencies/nested/m.rb"),
+  Padrino.root("fixtures/dependencies/nested/n.rb")
+)

--- a/padrino-core/test/fixtures/dependencies/nested/m.rb
+++ b/padrino-core/test/fixtures/dependencies/nested/m.rb
@@ -1,0 +1,5 @@
+class M
+  def self.hello
+    "hello"
+  end
+end

--- a/padrino-core/test/fixtures/dependencies/nested/n.rb
+++ b/padrino-core/test/fixtures/dependencies/nested/n.rb
@@ -1,0 +1,2 @@
+class N < J
+end

--- a/padrino-core/test/test_dependencies.rb
+++ b/padrino-core/test/test_dependencies.rb
@@ -53,5 +53,16 @@ describe "Dependencies" do
       assert_equal ["name"], F.fields
       assert_equal "", @io.string
     end
+
+    it 'should not remove constants that are newly commited in nested require_dependencies' do
+      capture_io do
+        Padrino.require_dependencies(
+          Padrino.root("fixtures/dependencies/nested/j.rb"),
+          Padrino.root("fixtures/dependencies/nested/k.rb"),
+          Padrino.root("fixtures/dependencies/nested/l.rb")
+        )
+      end
+      assert_equal "hello", M.hello
+    end
   end
 end


### PR DESCRIPTION
 #5 の適切な修正

根本的な問題は`Reloader.remove_constant`をした際に`MTIME`のキャッシュを消さないから、
Rollbackしたのにも関わらず、再度requireされるべきときに既に読込済とされてrequireされないこと。

`Reloader.remove_constant`したのだから再度`require`されるべき。という話